### PR TITLE
Control via keyboard fix

### DIFF
--- a/youtube-minimal-fixs.user.js
+++ b/youtube-minimal-fixs.user.js
@@ -263,7 +263,7 @@ SOFTWARE.
         if (!controlsInitialized) {
             controlsInitialized = true;
 
-            let pb = document.querySelector('.player-controls-pb .ytm-progress-bar')
+            let pb = document.querySelector('.player-controls-content .YtmProgressBarProgressBar')
 
             if (!pb) {
                 console.log("'.player-controls-pb .ytm-progress-bar' cannot be found");


### PR DESCRIPTION
Hello, that's a lil Fix, that help me on macOS Sonoma in Safari enable keyboard control.  
Fix control (Safari)